### PR TITLE
Scala 2.12 support added

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -20,4 +20,4 @@ It will modify all POM files from the SANSA projects and change the artitfact ID
 the suffix `_SCALAVERSION` will be modified.
 Moreover, we also replace the `scala.binary.version` in the POM file of the SANSA-Parent module.
 
-Note, currently the layers to process is hard coded in https://github.com/SANSA-Stack/SANSA-Parent/blob/scala-2.12/change-scala-version.sh#L51 , `order=(parent rdf ...)`, thus for additional projects this line has to be adapted, otherwise they will simply be ignored by the script.
+Note, currently the layers to process is hard coded in the array `order=(parent rdf ...)`, thus for additional projects this line has to be adapted, otherwise they will simply be ignored by the script.

--- a/NOTES.md
+++ b/NOTES.md
@@ -5,3 +5,17 @@
 mvn -N versions:update-parent -DparentVersion='[0.6.0-SNAPSHOT]' -DallowSnapshots=true versions:update-child-modules
 ```
 
+### Change Scala version
+Prerequisites: We assume that all SANSA projects supposed to be changed are located in the same parent directory 
+
+Run script from within the current project directory and provide the Scala version, i.e. either 2.11 or 2.12
+Example to change to Scala 2.12
+```bash
+./change-scala-version.sh 2.12
+```
+It will modify all POM files from the SANSA projects and change the artitfact ID, i.e. assuming the current layout
+
+`sansa-LAYERNAME-MODULENAME_SCALAVERSION`
+
+the suffix `_SCALAVERSION` will be modified.
+Moreover, we also replace the `scala.binary.version` in the POM file of the SANSA-Parent module.

--- a/NOTES.md
+++ b/NOTES.md
@@ -19,3 +19,5 @@ It will modify all POM files from the SANSA projects and change the artitfact ID
 
 the suffix `_SCALAVERSION` will be modified.
 Moreover, we also replace the `scala.binary.version` in the POM file of the SANSA-Parent module.
+
+Note, currently the layers to process is hard coded in https://github.com/SANSA-Stack/SANSA-Parent/blob/scala-2.12/change-scala-version.sh#L51 , `order=(parent rdf ...)`, thus for additional projects this line has to be adapted, otherwise they will simply be ignored by the script.

--- a/change-scala-version.sh
+++ b/change-scala-version.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+VALID_VERSIONS=( 2.11 2.12 )
+
+usage() {
+  echo "Usage: $(basename $0) [-h|--help] <version>
+where :
+  -h| --help Display this help text
+  valid version values : ${VALID_VERSIONS[*]}
+" 1>&2
+  exit 1
+}
+
+if [[ ($# -ne 1) || ( $1 == "--help") ||  $1 == "-h" ]]; then
+  usage
+fi
+
+TO_VERSION=$1
+
+check_scala_version() {
+  for i in ${VALID_VERSIONS[*]}; do [ $i = "$1" ] && return 0; done
+  echo "Invalid Scala version: $1. Valid versions: ${VALID_VERSIONS[*]}" 1>&2
+  exit 1
+}
+
+check_scala_version "$TO_VERSION"
+
+if [ $TO_VERSION = "2.12" ]; then
+  FROM_VERSION="2.11"
+else
+  FROM_VERSION="2.12"
+fi
+
+sed_i() {
+  sed -e "$1" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
+}
+
+export -f sed_i
+
+BASEDIR=$(dirname $0)/..
+find "$BASEDIR" -name 'pom.xml' -not -path '*target*' -print \
+  -exec bash -c "sed_i 's/\(artifactId.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' {}" \;
+
+# Also update <scala.binary.version> in parent POM
+# Match any scala binary version to ensure idempotency
+sed_i '1,/<scala\.binary\.version>[0-9]*\.[0-9]*</s/<scala\.binary\.version>[0-9]*\.[0-9]*</<scala.binary.version>'$TO_VERSION'</' \
+  "$BASEDIR/pom.xml"
+
+# Update source of scaladocs
+echo "$BASEDIR/docs/_plugins/copy_api_dirs.rb"
+sed_i 's/scala\-'$FROM_VERSION'/scala\-'$TO_VERSION'/' "$BASEDIR/docs/_plugins/copy_api_dirs.rb"

--- a/change-scala-version.sh
+++ b/change-scala-version.sh
@@ -47,8 +47,8 @@ sed_i() {
 export -f sed_i
 
 
-order=(parent rdf)
-#order=(parent rdf owl query inference ml examples)
+#order=(parent rdf)
+order=(parent rdf owl query inference ml examples)
 #order=(parent rdf owl query ml examples)
 
 BASEDIR=`pwd`

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
 			<dependency>
 				<groupId>com.twitter</groupId>
-				<artifactId>chill_2.11</artifactId>
+				<artifactId>chill_${scala.binary.version}</artifactId>
 				<version>0.9.3</version>
 			</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1461,6 +1461,21 @@
 
 	<profiles>
 
+		<!-- switch Scala version to 2.12 -->
+		<profile>
+			<id>scala-2.12</id>
+			<properties>
+				<scala.version>2.12.10</scala.version>
+				<scala.binary.version>2.12</scala.binary.version>
+			</properties>
+			<build>
+				<pluginManagement>
+					<plugins>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+
 		<!-- the profile used for deployment to Sonatype Maven repository -->
 		<profile>
 			<id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>net.sansa-stack</groupId>
-	<artifactId>sansa-parent</artifactId>
+	<artifactId>sansa-parent_2.11</artifactId>
 	<version>0.7.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>SANSA - Parent</name>
@@ -72,6 +72,8 @@
 		<sansa.version>${project.version}</sansa.version>
 		<sansa.datalake.version>0.1.2</sansa.datalake.version>
 		<scalastyle.config.path>${project.basedir}/scalastyle-config.xml</scalastyle.config.path>
+
+		<CodeCacheSize>1g</CodeCacheSize>
 	</properties>
 
 
@@ -908,7 +910,7 @@
 				<plugin>
 					<groupId>net.alchim31.maven</groupId>
 					<artifactId>scala-maven-plugin</artifactId>
-					<version>4.0.2</version>
+					<version>4.3.1</version>
 					<executions>
 						<execution>
 							<goals>
@@ -918,6 +920,8 @@
 							</goals>
 							<configuration>
 								<scalaVersion>${scala.version}</scalaVersion>
+								<checkMultipleScalaVersions>true</checkMultipleScalaVersions>
+								<failOnMultipleScalaVersions>true</failOnMultipleScalaVersions>
 								<recompileMode>incremental</recompileMode>
 								<useZincServer>true</useZincServer>
 								<args>
@@ -934,8 +938,6 @@
 									<jvmArg>-Xss10m</jvmArg>
 									<jvmArg>-Xms1024m</jvmArg>
 									<jvmArg>-Xmx1024m</jvmArg>
-									<jvmArg>-XX:PermSize=${PermGen}</jvmArg>
-									<jvmArg>-XX:MaxPermSize=${MaxPermGen}</jvmArg>
 									<jvmArg>-XX:ReservedCodeCacheSize=${CodeCacheSize}</jvmArg>
 								</jvmArgs>
 								<!--<javacArgs> -->
@@ -960,7 +962,7 @@
 
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.7.0</version>
+					<version>3.8.1</version>
 					<configuration>
 						<source>${maven.compiler.source}</source>
 						<target>${maven.compiler.target}</target>
@@ -1267,7 +1269,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-pmd-plugin</artifactId>
-					<version>3.8</version>
+					<version>3.13.0</version>
 					<configuration>
 						<linkXref>true</linkXref>
 						<sourceEncoding>utf-8</sourceEncoding>


### PR DESCRIPTION
Scala 2.12 support prepared
* aligned the artifact ID to common layout `sansa-LAYER_SCALAVERSION`
* fixed some hard-coded Scala binary versions in POM managed dependencies
* added script to change Scala version in other SANSA projects 